### PR TITLE
Exclude dyninstAPI_RT from link list in generic/xmas_tree

### DIFF
--- a/generic/CMakeLists.txt
+++ b/generic/CMakeLists.txt
@@ -15,7 +15,6 @@ target_link_libraries(
          dynC_API
          dynDwarf
          dynElf
-         dyninstAPI_RT
          dyninstAPI
          instructionAPI
          parseAPI


### PR DESCRIPTION
There is no link target exported by Dyninst for the runtime library.