### PR TITLE
Fix symtab header include ordering

### DIFF
--- a/symtab/enum/parser.cpp
+++ b/symtab/enum/parser.cpp
@@ -1,5 +1,5 @@
-#include "Function.h"
 #include "Symtab.h"
+#include "Function.h"
 #include <exception>
 #include <iostream>
 #include <sstream>

--- a/symtab/insertion_operators.cpp
+++ b/symtab/insertion_operators.cpp
@@ -1,9 +1,9 @@
+#include "Symtab.h"
+#include "Symbol.h"
 #include "Aggregate.h"
 #include "Function.h"
 #include "Module.h"
 #include "StringTable.h"
-#include "Symbol.h"
-#include "Symtab.h"
 #include "Variable.h"
 
 #include <iostream>

--- a/symtab/parse_function_params.cpp
+++ b/symtab/parse_function_params.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 #include <vector>
 
-#include <Function.h>
 #include <Symtab.h>
+#include <Function.h>
 #include <Type.h>
 #include <Variable.h>
 


### PR DESCRIPTION
You have to include Symtab.h first as the other headers refer to types that are assumed to have been defined.