### PR TITLE
CI deps-from-source: direct output to /dev/stdout instead of 'stdout'

### DIFF
--- a/.github/workflows/deps-from-source.yaml
+++ b/.github/workflows/deps-from-source.yaml
@@ -21,4 +21,4 @@ jobs:
       - name: build
         run: |
           cd /
-          bash test.sh -n 2 -l stdout
+          bash test.sh -n 2 -l /dev/stdout


### PR DESCRIPTION
The latter creates a local file called 'stdout' instead of printing to the standard output stream.