### PR TITLE
Remove instructionAPI/RegisterIDs.h

### DIFF
--- a/generic/xmas_tree.cpp
+++ b/generic/xmas_tree.cpp
@@ -112,7 +112,6 @@
 #include "RangeLookup.h"
 #include "Region.h"
 #include "Register.h"
-#include "RegisterIDs.h"
 #include "Result.h"
 #include "slicing.h"
 #include "snippetGen.h"

--- a/instructionAPI/includes.cpp
+++ b/instructionAPI/includes.cpp
@@ -10,7 +10,6 @@
 #include "Operand.h"
 #include "Operation_impl.h"
 #include "Register.h"
-#include "RegisterIDs.h"
 #include "Result.h"
 #include "Ternary.h"
 #include "Visitor.h"


### PR DESCRIPTION
It's getting removed from Dyninst because it's no longer used.