### PR TITLE
Add parseAPI/simpleParser

### DIFF
--- a/parseAPI/CMakeLists.txt
+++ b/parseAPI/CMakeLists.txt
@@ -2,3 +2,8 @@ project(parseAPI)
 
 add_executable(parseAPI_includes includes.cpp)
 target_link_libraries(parseAPI_includes PRIVATE Dyninst::parseAPI)
+
+add_executable(simpleParser simpleParser.cpp)
+target_link_libraries(simpleParser PRIVATE Dyninst::parseAPI)
+add_test(NAME parseAPI_simpleParser
+         COMMAND sh -c "./simpleParser simpleParser")

--- a/parseAPI/simpleParser.cpp
+++ b/parseAPI/simpleParser.cpp
@@ -1,0 +1,23 @@
+#include "CFG.h"
+#include "CodeObject.h"
+#include <iostream>
+
+namespace dp = Dyninst::ParseAPI;
+int main(int argc, char* argv[]) {
+  if(argc < 2 || argc > 3) {
+    std::cerr << "Usage: " << argv[0] << " file\n";
+    return -1;
+  }
+
+  try {
+    auto* sts = new dp::SymtabCodeSource(argv[1]);
+    auto* co = new dp::CodeObject(sts);
+    co->parse();
+  } catch(std::exception &e) {
+    std::cerr << e.what() << '\n';
+    return -1;
+  } catch(...) {
+    std::cerr << "unknown exception occurred\n";
+    return -1;
+  }
+}


### PR DESCRIPTION
This is both a good sanity check for PRs and can be used as a larger system-level parser for things like running through /usr/lib.