### PR TITLE
Add register uniqueness test

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Build tests
         run: |
            cd tests
-           flags="-DCMAKE_C_FLAGS='-Werror' -DCMAKE_CXX_FLAGS='-Werror'"
+           flags="-DCMAKE_C_FLAGS='-Werror' -DCMAKE_CXX_FLAGS='-Werror' -std=c++17"
            cmake . -DDyninst_DIR=/dyninst/install/lib/cmake/Dyninst $flags
            cmake --build .
       - name: Run tests
@@ -49,7 +49,7 @@ jobs:
       - name: Build tests
         run: |
            cd tests
-           flags="-DCMAKE_C_FLAGS='-Werror' -DCMAKE_CXX_FLAGS='-Werror' "
+           flags="-DCMAKE_C_FLAGS='-Werror' -DCMAKE_CXX_FLAGS='-Werror' -std=c++17"
            flags="$flags -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ "
            cmake . -DDyninst_DIR=/dyninst/install/lib/cmake/Dyninst $flags
            cmake --build .

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Build tests
         run: |
            cd tests
-           flags="-DCMAKE_C_FLAGS='-Werror' -DCMAKE_CXX_FLAGS='-Werror' -std=c++17"
+           flags="-DCMAKE_C_FLAGS='-Werror' -DCMAKE_CXX_FLAGS='-Werror' -DCMAKE_CXX_STANDARD=17"
            cmake . -DDyninst_DIR=/dyninst/install/lib/cmake/Dyninst $flags
            cmake --build .
       - name: Run tests
@@ -49,7 +49,7 @@ jobs:
       - name: Build tests
         run: |
            cd tests
-           flags="-DCMAKE_C_FLAGS='-Werror' -DCMAKE_CXX_FLAGS='-Werror' -std=c++17"
+           flags="-DCMAKE_C_FLAGS='-Werror' -DCMAKE_CXX_FLAGS='-Werror' -DCMAKE_CXX_STANDARD=17"
            flags="$flags -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ "
            cmake . -DDyninst_DIR=/dyninst/install/lib/cmake/Dyninst $flags
            cmake --build .

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(common)
 
+add_subdirectory(registers)
+
 add_executable(common_insertion_operators insertion_operators.cpp)
 target_link_libraries(common_insertion_operators PRIVATE Dyninst::common)
 

--- a/common/registers/CMakeLists.txt
+++ b/common/registers/CMakeLists.txt
@@ -1,0 +1,5 @@
+project(common_registers)
+
+add_executable(uniqueness uniqueness.cpp)
+target_link_libraries(uniqueness PRIVATE Dyninst::symtabAPI)
+add_test(NAME common_registers_uniqueness COMMAND uniqueness)

--- a/common/registers/uniqueness.cpp
+++ b/common/registers/uniqueness.cpp
@@ -1,0 +1,70 @@
+#include "registers/MachRegister.h"
+#include "Architecture.h"
+#include <iostream>
+#include <unordered_map>
+#include <string>
+#include <cstdlib>
+#include <map>
+#include <vector>
+
+/*
+ * Ensure all registers for an architecture have unique representations
+ */
+
+// Some architectures have known aliases, so exclude them.
+using dup_map = std::map<Dyninst::Architecture, std::vector<char const*>>;
+dup_map known_dups = {
+  {Dyninst::Arch_aarch64,
+    {
+      "aarch64::x29", "aarch64::fp",
+      "aarch64::x30", "aarch64::lr",
+      "aarch64::Ip0", "aarch64::x16",
+      "aarch64::Ip1", "aarch64::x17",
+    }
+  },
+  {Dyninst::Arch_x86, {}},
+  {Dyninst::Arch_x86_64, {}},
+};
+
+bool check(Dyninst::Architecture arch) {
+  auto const& regs = Dyninst::MachRegister::getAllRegistersForArch(arch);
+
+  auto known_dup = [arch](std::string const& name) {
+    auto const& regs = known_dups[arch];
+    return std::find(regs.begin(), regs.end(), name) != regs.end();
+  };
+
+  auto success = true;
+
+  std::unordered_map<unsigned int, std::string> vals;
+  for(auto r : regs) {
+    auto [itr, inserted] = vals.insert({r.val(), r.name()});
+    if(!inserted && !known_dup(r.name())) {
+      auto [val, name] = *itr;
+      std::cerr << "Duplicate: 0x" << std::hex << val
+                << "  " << r.name() << ", " << name << "\n";
+      success = false;
+    }
+  }
+
+  return success;
+}
+
+
+int main() {
+  auto status = EXIT_SUCCESS;
+  
+  if(!check(Dyninst::Arch_aarch64)) {
+    status = EXIT_FAILURE;
+  }
+  if(!check(Dyninst::Arch_x86)) {
+    status = EXIT_FAILURE;
+  }
+  if(!check(Dyninst::Arch_x86_64)) {
+    status = EXIT_FAILURE;
+  }
+  if(!check(Dyninst::Arch_ppc64)) {
+    status = EXIT_FAILURE;
+  }
+  return status;
+}


### PR DESCRIPTION
This ensures that all register values are unique for a given architecture. ppc32 is explicitly not tested because they are not supported.