### PR TITLE
Add tests for DWARF line maps and variable information

### DIFF
--- a/symtab/CMakeLists.txt
+++ b/symtab/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(st_insertion_operators PRIVATE Dyninst::symtabAPI)
 
 add_subdirectory(enum)
 add_subdirectory(module)
+add_subdirectory(DWARF)
 
 add_executable(symtab_includes includes.cpp)
 target_link_libraries(symtab_includes PRIVATE Dyninst::symtabAPI)

--- a/symtab/DWARF/CMakeLists.txt
+++ b/symtab/DWARF/CMakeLists.txt
@@ -1,0 +1,5 @@
+include_guard(GLOBAL)
+
+add_executable(variable_locations variable_locations.cpp)
+target_compile_options(variable_locations PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+target_link_libraries(variable_locations PRIVATE Dyninst::symtabAPI)

--- a/symtab/DWARF/CMakeLists.txt
+++ b/symtab/DWARF/CMakeLists.txt
@@ -3,3 +3,7 @@ include_guard(GLOBAL)
 add_executable(variable_locations variable_locations.cpp)
 target_compile_options(variable_locations PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
 target_link_libraries(variable_locations PRIVATE Dyninst::symtabAPI)
+
+add_executable(linemaps linemaps.cpp)
+target_compile_options(linemaps PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+target_link_libraries(linemaps PRIVATE Dyninst::symtabAPI)

--- a/symtab/DWARF/linemaps.cpp
+++ b/symtab/DWARF/linemaps.cpp
@@ -1,0 +1,150 @@
+#include "Symtab.h"
+#include "Function.h"
+#include "Variable.h"
+
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+namespace ds = Dyninst::SymtabAPI;
+
+bool check_pc_ranges(ds::Module *, ds::Function *);
+bool check_local_vars(ds::Module *, ds::Function *);
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " file\n";
+    return EXIT_FAILURE;
+  }
+
+  auto *filename = argv[1];
+  ds::Symtab *symtab{};
+
+  if (!ds::Symtab::openFile(symtab, filename)) {
+    std::cerr << "Unable to open file '" << filename << "'\n";
+    return EXIT_FAILURE;
+  }
+
+  bool passed = true;
+
+  if (symtab->getAllFunctionsRef().empty()) {
+    std::cerr << "No functions found in '" << filename << "'\n";
+    return EXIT_FAILURE;
+  }
+
+  for (auto *f : symtab->getAllFunctionsRef()) {
+    auto *mod = f->getModule();
+
+    if (mod->fullName().empty()) {
+      std::cerr << "no source file found\n";
+      passed = false;
+      continue;
+    }
+
+    if (!check_pc_ranges(mod, f)) {
+      passed = false;
+      continue;
+    }
+
+    if (!check_local_vars(mod, f)) {
+      passed = false;
+      continue;
+    }
+    break;
+  }
+
+  return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+/*
+ *  Ensure local variables (including function parameters)
+ *  have entries in the line map.
+ */
+bool check_local_vars(ds::Module *mod, ds::Function *f) {
+  bool passed = true;
+
+  auto lvars = [f]() {
+    std::vector<ds::localVar *> lvars;
+    f->getParams(lvars);
+    f->getLocalVariables(lvars);
+    return lvars;
+  }();
+
+  // Print filename
+  bool printed_funcname = false;
+  auto pfn = [&]() -> std::ostream & {
+    if (!printed_funcname) {
+      std::cerr << "\nAnalyzing function " << f->getName() << ":\n";
+    }
+    printed_funcname = true;
+    return std::cerr;
+  };
+
+  for (auto *var : lvars) {
+    auto const &var_name = var->getName();
+
+    // compilers don't always emit line information for the implicit 'this'
+    // Don't consider this an error.
+    if(var_name == "this") {
+      continue;
+    }
+
+    if (var->getFileName().empty()) {
+      pfn() << "\tno source file found for variable '" << var_name << "'\n";
+      passed = false;
+      continue;
+    }
+
+    if (var->getFileName() != mod->fullName()) {
+      pfn() << "\t'" << var_name << "': source file '" << var->getFileName()
+            << "' does not match function's source file '" << mod->fullName() << "'.\n";
+      passed = false;
+      continue;
+    }
+
+    const int line = var->getLineNum();
+    if (line == 0) {
+      pfn() << "\tvariable '" << var_name << "' declared on line 0.\n";
+      passed = false;
+      continue;
+    }
+
+    if (line < 0) {
+      pfn() << "\tvariable '" << var_name << "' declared on negative line number.\n";
+      passed = false;
+      continue;
+    }
+  }
+
+  return passed;
+}
+
+/*
+ *  Ensure every code range covered by a function has a corresponding
+ *  entry in the line map.
+ */
+bool check_pc_ranges(ds::Module *mod, ds::Function *f) {
+  bool passed = true;
+
+  // Print filename
+  bool printed_funcname = false;
+  auto pfn = [&]() -> std::ostream & {
+    if (!printed_funcname) {
+      std::cerr << "\n" << f->getName() << ":\n";
+    }
+    printed_funcname = true;
+    return std::cerr;
+  };
+
+  for (auto const &range : f->getRanges()) {
+    std::vector<ds::Statement::Ptr> statements;
+    for (auto pc : {range.low(), range.high()}) {
+      if (!mod->getSourceLines(statements, pc)) {
+        pfn() << "\tno line info for PC " << pc << "\n";
+        passed = false;
+        continue;
+      }
+    }
+  }
+  return passed;
+}

--- a/symtab/DWARF/variable_locations.cpp
+++ b/symtab/DWARF/variable_locations.cpp
@@ -1,0 +1,69 @@
+#include "Symtab.h"
+#include "Function.h"
+#include "Variable.h"
+#include "VariableLocation.h"
+
+#include <iostream>
+#include <vector>
+
+namespace ds = Dyninst::SymtabAPI;
+
+static std::ostream& operator<<(std::ostream &os, Dyninst::VariableLocation const &loc) {
+  return os << '[' << std::hex << loc.lowPC << ", " << std::hex << loc.hiPC << ')';
+}
+
+static std::ostream& operator<<(std::ostream &os, ds::FuncRange const &range) {
+  return os << '[' << std::hex << range.low() << ", " << std::hex << range.high() << ')';
+}
+
+/*
+ *  Test that all local variables and parameters have DWARF locations
+ *  within the bounds of their containing function.
+ */
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " file\n";
+    return EXIT_FAILURE;
+  }
+
+  auto *filename = argv[1];
+  ds::Symtab *symtab{};
+
+  if (!ds::Symtab::openFile(symtab, filename)) {
+    std::cerr << "Unable to open file '" << filename << "'\n";
+    return EXIT_FAILURE;
+  }
+
+  bool failed = false;
+
+  for (auto *f : symtab->getAllFunctionsRef()) {
+    std::clog << "Checking function '" << f->getName() << "'\n";
+
+    std::vector<ds::localVar *> lvars;
+    f->getParams(lvars);
+    f->getLocalVariables(lvars);
+
+    for (auto *var : lvars) {
+      std::clog << "Checking variable '" << var->getName() << "' ["
+                << var->getFileName() << ':' << var->getLineNum() << "]\n";
+
+      for (auto var_loc : var->getLocationLists()) {
+        if (var_loc.lowPC == 0 || var_loc.hiPC >= 0xFFFFFFFF) {
+          std::cerr << "Location is likely bad " << var_loc << "\n";
+          failed = true;
+        }
+        for (auto const &func_loc : f->getRanges()) {
+          if (var_loc.lowPC < func_loc.low() || var_loc.hiPC > func_loc.high()) {
+            std::clog << "Outside of function range!\n"
+                      << "  var = " << var_loc << "\n"
+                      << "  func = " << func_loc << "\n";
+            failed = true;
+          }
+        }
+      }
+    }
+  }
+
+  return failed ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
Adapted from https://github.com/woodard/dwqual

These are not intended to be used via `ctest`. Rather, they should be used in the Dyninst `pr-tests` workflow. I'll add that later.

---

This exposes a very serious non-determinism in linemap parsing. Note that the linemap test explicitly ignores the implicit `this` parameter because compilers don't always emit a line entry for it (see also https://github.com/dyninst/dyninst/issues/647).

```
for i in $(seq 10); do
  echo "Run $i"
  symtab/DWARF/linemaps /path/to/dyninst/lib/libcommon.so
  echo -e "\n\n"
done

Run 1

Analyzing function _ZNSt8_Rb_treeIPKN5boost6system14error_categoryESt4pairIKS4_St10unique_ptrINS1_6detail12std_categoryESt14default_deleteIS9_EEESt10_Select1stISD_ENS8_12cat_ptr_lessESaISD_EE16_M_insert_uniqueISD_EES5_ISt17_Rb_tree_iteratorISD_EbEOT_:
	'__v': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
	'__res': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
'symtab/DWARF/linemaps /home/tim/paradyn/dyninst/build/install/lib/libcommon.so' failed

Analyzing function _ZNSt8_Rb_treeIPKN5boost6system14error_categoryESt4pairIKS4_St10unique_ptrINS1_6detail12std_categoryESt14default_deleteIS9_EEESt10_Select1stISD_ENS8_12cat_ptr_lessESaISD_EE16_M_insert_uniqueISD_EES5_ISt17_Rb_tree_iteratorISD_EbEOT_:
	'__v': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
	'__res': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
'symtab/DWARF/linemaps /home/tim/paradyn/dyninst/build/install/lib/libcommon.so' failed



Run 2



Run 3



Run 4

Analyzing function _ZNSt8_Rb_treeIPKN5boost6system14error_categoryESt4pairIKS4_St10unique_ptrINS1_6detail12std_categoryESt14default_deleteIS9_EEESt10_Select1stISD_ENS8_12cat_ptr_lessESaISD_EE16_M_insert_uniqueISD_EES5_ISt17_Rb_tree_iteratorISD_EbEOT_:
	'__v': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
	'__res': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
'symtab/DWARF/linemaps /home/tim/paradyn/dyninst/build/install/lib/libcommon.so' failed



Run 5



Run 6

Analyzing function _ZNSt8_Rb_treeIPKN5boost6system14error_categoryESt4pairIKS4_St10unique_ptrINS1_6detail12std_categoryESt14default_deleteIS9_EEESt10_Select1stISD_ENS8_12cat_ptr_lessESaISD_EE16_M_insert_uniqueISD_EES5_ISt17_Rb_tree_iteratorISD_EbEOT_:
	'__v': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
	'__res': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
'symtab/DWARF/linemaps /home/tim/paradyn/dyninst/build/install/lib/libcommon.so' failed

Analyzing function _ZNSt8_Rb_treeIPKN5boost6system14error_categoryESt4pairIKS4_St10unique_ptrINS1_6detail12std_categoryESt14default_deleteIS9_EEESt10_Select1stISD_ENS8_12cat_ptr_lessESaISD_EE16_M_insert_uniqueISD_EES5_ISt17_Rb_tree_iteratorISD_EbEOT_:
	'__v': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
	'__res': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
'symtab/DWARF/linemaps /home/tim/paradyn/dyninst/build/install/lib/libcommon.so' failed



Run 7



Run 8

Analyzing function _ZNSt8_Rb_treeIPKN5boost6system14error_categoryESt4pairIKS4_St10unique_ptrINS1_6detail12std_categoryESt14default_deleteIS9_EEESt10_Select1stISD_ENS8_12cat_ptr_lessESaISD_EE16_M_insert_uniqueISD_EES5_ISt17_Rb_tree_iteratorISD_EbEOT_:
	'__v': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
	'__res': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
'symtab/DWARF/linemaps /home/tim/paradyn/dyninst/build/install/lib/libcommon.so' failed



Run 9

Analyzing function _ZNSt8_Rb_treeIPKN5boost6system14error_categoryESt4pairIKS4_St10unique_ptrINS1_6detail12std_categoryESt14default_deleteIS9_EEESt10_Select1stISD_ENS8_12cat_ptr_lessESaISD_EE16_M_insert_uniqueISD_EES5_ISt17_Rb_tree_iteratorISD_EbEOT_:
	'__v': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
	'__res': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
'symtab/DWARF/linemaps /home/tim/paradyn/dyninst/build/install/lib/libcommon.so' failed

Analyzing function _ZNSt8_Rb_treeIPKN5boost6system14error_categoryESt4pairIKS4_St10unique_ptrINS1_6detail12std_categoryESt14default_deleteIS9_EEESt10_Select1stISD_ENS8_12cat_ptr_lessESaISD_EE16_M_insert_uniqueISD_EES5_ISt17_Rb_tree_iteratorISD_EbEOT_:
	'__v': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
	'__res': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
'symtab/DWARF/linemaps /home/tim/paradyn/dyninst/build/install/lib/libcommon.so' failed



Run 10

Analyzing function _ZNSt8_Rb_treeIPKN5boost6system14error_categoryESt4pairIKS4_St10unique_ptrINS1_6detail12std_categoryESt14default_deleteIS9_EEESt10_Select1stISD_ENS8_12cat_ptr_lessESaISD_EE16_M_insert_uniqueISD_EES5_ISt17_Rb_tree_iteratorISD_EbEOT_:
	'__v': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
	'__res': source file '/usr/include/c++/11/bits/stl_tree.h' does not match function's source file '/home/tim/paradyn/dyninst/common/src/arch-x86.C'.
'symtab/DWARF/linemaps /home/tim/paradyn/dyninst/build/install/lib/libcommon.so' failed
```