### PR TITLE
Remove BPatch_Set

### DIFF
--- a/dyninstAPI/includes.cpp
+++ b/dyninstAPI/includes.cpp
@@ -18,7 +18,6 @@
 #include "BPatch_object.h"
 #include "BPatch_point.h"
 #include "BPatch_process.h"
-#include "BPatch_Set.h"
 #include "BPatch_snippet.h"
 #include "BPatch_sourceBlock.h"
 #include "BPatch_sourceObj.h"

--- a/generic/xmas_tree.cpp
+++ b/generic/xmas_tree.cpp
@@ -33,7 +33,6 @@
 #include "BPatch_object.h"
 #include "BPatch_point.h"
 #include "BPatch_process.h"
-#include "BPatch_Set.h"
 #include "BPatch_snippet.h"
 #include "BPatch_sourceBlock.h"
 #include "BPatch_sourceObj.h"


### PR DESCRIPTION
BPatch_Set has been deprecated since at least 2018 and is now being removed from Dyninst.